### PR TITLE
Fix `LanguageTag.SetLangTagInUrlPath`

### DIFF
--- a/src/i18n.Core.Abstractions/Domain/LanguageTag.cs
+++ b/src/i18n.Core.Abstractions/Domain/LanguageTag.cs
@@ -554,16 +554,19 @@ namespace i18n.Core.Abstractions.Domain
                 if (Uri.TryCreate(url, UriKind.Absolute, out uri))
                 {
                     var ub = new UriBuilder(url);
-                    var urlNew = ExtractLangTagFromUrl(ub.Path, UriKind.Relative, out urlPatched);
+                    var langtag = ExtractLangTagFromUrl(ub.Path, UriKind.Relative, out var strPatchedPath);
                     // Match?
-                    if (urlNew != null)
+                    if (langtag != null)
                     {
-                        ub.Path = urlNew;
-                        return ub.Uri.ToString(); // Go via Uri to avoid port 80 being added.
+                        ub.Path = strPatchedPath;
+                        urlPatched = ub.Uri.ToString(); // Go via Uri to avoid port 80 being added.
                     }
                     // No match.
-                    urlPatched = url;
-                    return null;
+                    else
+                    {
+                        urlPatched = url;
+                    }
+                    return langtag;
                 }
             }
 

--- a/src/i18n.Core.Abstractions/Extensions/StringExtensions.cs
+++ b/src/i18n.Core.Abstractions/Extensions/StringExtensions.cs
@@ -52,7 +52,7 @@ namespace i18n.Core.Abstractions.Extensions
                 sb.Append("/");
             }
             sb.Append(folder);
-            if (!(url).IsSet() || url == "/")
+            if (url.IsSet() && url != "/")
             {
                 if (url[0] != '/')
                 {


### PR DESCRIPTION
This fixes a couple of bugs when `LanguageTag.SetLangTagInUrlPath` is called.

The first is that the behaviour of Extension.UrlPrependPath differs slightly from the turqoiseowl's i18n repository for some reason. I'm unsure why this logic was reversed but it appears to be deliberate and is the only change in this method at the time it was forked. Maybe something got muddled when running the R# refactor?

The second bug is due to an issue in turqoiseowl's i18n repository at the time it was forked to create this repo. That bug has since [been fixed](https://github.com/turquoiseowl/i18n/commit/395ff751e1c1cbfce396b058e21aa44674dc1bc3) but it doesn't look like any changes has been synced from that repo since initial commit.